### PR TITLE
Atualiza sistema de verificação de atualizações do GitHub

### DIFF
--- a/Screens/frmConfig.cs
+++ b/Screens/frmConfig.cs
@@ -5,12 +5,14 @@ using System.Diagnostics;
 using System.Drawing;
 using System.IO;
 using System.Linq;
+using System.Net.Http;
+using System.Reflection;
 using System.ServiceProcess;
 using System.Text;
 using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
-using System.Threading;
 using ThGameMode.Utils;
 
 namespace ThGameMode.Screens
@@ -37,6 +39,7 @@ namespace ThGameMode.Screens
         private Icon _iconAltoDesempenho;
         private Icon _iconPadrao;
         private ContextMenuStrip _trayMenu;
+        private ToolStripMenuItem? _downloadUpdateMenuItem;
         private bool _quitRequested = false;
         private readonly bool _startMinimized;
 
@@ -50,6 +53,9 @@ namespace ThGameMode.Screens
         private System.Windows.Forms.Timer _tooltipTimer;
 
         private bool _isHighPerformance = false;
+        private readonly GitHubReleaseChecker _releaseChecker = new();
+        private string? _latestReleaseUrl;
+        private bool _updateNotificationPendingOpen;
 
 
 
@@ -99,6 +105,7 @@ namespace ThGameMode.Screens
                 // Inicia monitor automaticamente (modo padrão ligado)
                 StartMonitor();
                 AppLogger.Write(AppLogger.LogLevel.Info, $"Monitor iniciado automaticamente.");
+                _ = CheckForUpdatesAsync(false);
 
                 if (_startMinimized)
                 {
@@ -126,6 +133,14 @@ namespace ThGameMode.Screens
             _trayMenu.Items.Add("Desativar detecção", null, (s, e) => StopMonitor());
             _trayMenu.Items.Add(new ToolStripSeparator());
             _trayMenu.Items.Add("Abrir configurações", null, (s, e) => ShowWindow());
+            _trayMenu.Items.Add("Verificar atualizações", null, async (s, e) => await CheckForUpdatesAsync(true));
+
+            _downloadUpdateMenuItem = new ToolStripMenuItem("Baixar nova versão")
+            {
+                Enabled = false
+            };
+            _downloadUpdateMenuItem.Click += (s, e) => OpenLatestReleasePage();
+            _trayMenu.Items.Add(_downloadUpdateMenuItem);
 
             var startupItem = new ToolStripMenuItem("Iniciar com Windows");
             startupItem.Checked = IsStartupEnabled();
@@ -148,6 +163,11 @@ namespace ThGameMode.Screens
                 Visible = true
             };
             _trayIcon.DoubleClick += (s, e) => ShowWindow();
+            _trayIcon.BalloonTipClicked += (s, e) =>
+            {
+                if (_updateNotificationPendingOpen)
+                    OpenLatestReleasePage();
+            };
 
            
 
@@ -316,6 +336,144 @@ namespace ThGameMode.Screens
                 : tooltip;
         }
 
+        #endregion
+
+        #region Updates
+        private async Task CheckForUpdatesAsync(bool manualCheck)
+        {
+            try
+            {
+                Version currentVersion = GetCurrentVersion();
+                AppLogger.Write(AppLogger.LogLevel.Info, $"Verificando atualização no GitHub. Versão atual: {currentVersion}");
+
+                var result = await _releaseChecker.CheckForUpdateAsync(currentVersion);
+
+                if (result.IsUpdateAvailable && !string.IsNullOrWhiteSpace(result.ReleaseUrl))
+                {
+                    _latestReleaseUrl = result.ReleaseUrl;
+                    _updateNotificationPendingOpen = true;
+
+                    if (_downloadUpdateMenuItem != null)
+                        _downloadUpdateMenuItem.Enabled = true;
+
+                    AppLogger.Write(AppLogger.LogLevel.Info, $"Nova versão encontrada: {result.LatestTag}");
+                    _trayIcon?.ShowBalloonTip(
+                        4000,
+                        "Atualização disponível",
+                        $"Nova versão encontrada ({result.LatestTag}). Clique para abrir a release no GitHub.",
+                        ToolTipIcon.Info);
+
+                    if (!_startMinimized && Visible && WindowState != FormWindowState.Minimized)
+                    {
+                        var answer = MessageBox.Show(
+                            $"Uma nova versão do ThGameMode está disponível no GitHub.\n\nVersão atual: {currentVersion}\nNova versão: {result.LatestTag}\n\nDeseja abrir a página da release agora?",
+                            "Atualização disponível",
+                            MessageBoxButtons.YesNo,
+                            MessageBoxIcon.Information);
+
+                        if (answer == DialogResult.Yes)
+                            OpenLatestReleasePage();
+                    }
+
+                    return;
+                }
+
+                _updateNotificationPendingOpen = false;
+                if (_downloadUpdateMenuItem != null)
+                    _downloadUpdateMenuItem.Enabled = false;
+
+                if (!string.IsNullOrWhiteSpace(result.FailureReason))
+                {
+                    AppLogger.Write(AppLogger.LogLevel.Warning, "Não foi possível validar a release mais recente: " + result.FailureReason);
+
+                    if (manualCheck)
+                    {
+                        MessageBox.Show(
+                            result.FailureReason,
+                            "Falha ao verificar atualizações",
+                            MessageBoxButtons.OK,
+                            MessageBoxIcon.Warning);
+                    }
+
+                    return;
+                }
+
+                if (manualCheck)
+                {
+                    MessageBox.Show(
+                        $"Você já está na versão mais recente ({currentVersion}).",
+                        "Sem atualizações",
+                        MessageBoxButtons.OK,
+                        MessageBoxIcon.Information);
+                }
+            }
+            catch (HttpRequestException ex)
+            {
+                AppLogger.Write(AppLogger.LogLevel.Warning, "Falha ao consultar atualização no GitHub: " + ex.Message);
+                if (manualCheck)
+                {
+                    MessageBox.Show(
+                        "Não foi possível verificar atualizações no GitHub no momento.",
+                        "Falha ao verificar atualizações",
+                        MessageBoxButtons.OK,
+                        MessageBoxIcon.Warning);
+                }
+            }
+            catch (TaskCanceledException ex)
+            {
+                AppLogger.Write(AppLogger.LogLevel.Warning, "Tempo esgotado ao verificar atualização: " + ex.Message);
+                if (manualCheck)
+                {
+                    MessageBox.Show(
+                        "A verificação de atualização expirou. Tente novamente em instantes.",
+                        "Falha ao verificar atualizações",
+                        MessageBoxButtons.OK,
+                        MessageBoxIcon.Warning);
+                }
+            }
+            catch (Exception ex)
+            {
+                AppLogger.Write(AppLogger.LogLevel.Error, "Erro inesperado ao verificar atualização: " + ex.Message);
+                if (manualCheck)
+                {
+                    MessageBox.Show(
+                        "Ocorreu um erro inesperado ao verificar atualizações.",
+                        "Falha ao verificar atualizações",
+                        MessageBoxButtons.OK,
+                        MessageBoxIcon.Warning);
+                }
+            }
+        }
+
+        private static Version GetCurrentVersion()
+        {
+            return Assembly.GetExecutingAssembly().GetName().Version ?? new Version(1, 0, 0, 0);
+        }
+
+        private void OpenLatestReleasePage()
+        {
+            if (string.IsNullOrWhiteSpace(_latestReleaseUrl))
+                return;
+
+            try
+            {
+                Process.Start(new ProcessStartInfo
+                {
+                    FileName = _latestReleaseUrl,
+                    UseShellExecute = true
+                });
+                _updateNotificationPendingOpen = false;
+            }
+            catch (Exception ex)
+            {
+                AppLogger.Write(AppLogger.LogLevel.Error, "Erro ao abrir página da release: " + ex.Message);
+                MessageBox.Show(
+                    "Não foi possível abrir a página da nova versão.",
+                    "Erro ao abrir release",
+                    MessageBoxButtons.OK,
+                    MessageBoxIcon.Warning);
+            }
+        }
         #endregion
 
         #region Config JSON I/O

--- a/ThGameMode.csproj
+++ b/ThGameMode.csproj
@@ -7,9 +7,9 @@
     <UseWindowsForms>true</UseWindowsForms>
     <ImplicitUsings>enable</ImplicitUsings>
     <ApplicationIcon>icon_padrao.ico</ApplicationIcon>
-    <Version>1.0.1</Version>
-    <AssemblyVersion>1.0.1</AssemblyVersion>
-    <FileVersion>1.0.1</FileVersion>
+    <Version>1.0.2</Version>
+    <AssemblyVersion>1.0.2</AssemblyVersion>
+    <FileVersion>1.0.2</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Utils/GitHubReleaseChecker.cs
+++ b/Utils/GitHubReleaseChecker.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Globalization;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace ThGameMode.Utils
+{
+    internal sealed class GitHubReleaseChecker
+    {
+        private const string Owner = "thalisonss";
+        private const string Repository = "ThGameMode";
+        private static readonly Uri LatestReleaseApiUri = new($"https://api.github.com/repos/{Owner}/{Repository}/releases/latest");
+
+        public async Task<ReleaseCheckResult> CheckForUpdateAsync(Version currentVersion, CancellationToken cancellationToken = default)
+        {
+            using var client = CreateHttpClient();
+            using var request = new HttpRequestMessage(HttpMethod.Get, LatestReleaseApiUri);
+            request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.github+json"));
+            request.Headers.Add("X-GitHub-Api-Version", "2022-11-28");
+
+            using var response = await client.SendAsync(request, cancellationToken).ConfigureAwait(false);
+
+            if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
+                return ReleaseCheckResult.NotAvailable(currentVersion, "Nenhuma release publicada foi encontrada no GitHub.");
+
+            response.EnsureSuccessStatusCode();
+
+            await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+            var release = await JsonSerializer.DeserializeAsync<GitHubReleaseResponse>(stream, cancellationToken: cancellationToken).ConfigureAwait(false);
+
+            if (release == null || string.IsNullOrWhiteSpace(release.TagName) || string.IsNullOrWhiteSpace(release.HtmlUrl))
+                return ReleaseCheckResult.NotAvailable(currentVersion, "A resposta da release veio incompleta.");
+
+            if (!TryParseVersion(release.TagName, out var latestVersion))
+                return ReleaseCheckResult.NotAvailable(currentVersion, $"Nao foi possivel interpretar a versao da tag '{release.TagName}'.");
+
+            return new ReleaseCheckResult(
+                latestVersion > currentVersion,
+                currentVersion,
+                latestVersion,
+                release.TagName,
+                release.Name,
+                release.HtmlUrl,
+                release.Body,
+                null);
+        }
+
+        private static HttpClient CreateHttpClient()
+        {
+            var client = new HttpClient
+            {
+                Timeout = TimeSpan.FromSeconds(8)
+            };
+
+            string version = Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "1.0.0";
+            client.DefaultRequestHeaders.UserAgent.ParseAdd($"ThGameMode/{version}");
+            return client;
+        }
+
+        private static bool TryParseVersion(string tagName, out Version version)
+        {
+            version = new Version(0, 0, 0, 0);
+
+            if (string.IsNullOrWhiteSpace(tagName))
+                return false;
+
+            string normalized = tagName.Trim();
+            if (normalized.StartsWith("v", true, CultureInfo.InvariantCulture))
+                normalized = normalized[1..];
+
+            int suffixIndex = normalized.IndexOfAny(['-', '+']);
+            if (suffixIndex >= 0)
+                normalized = normalized[..suffixIndex];
+
+            if (!Version.TryParse(normalized, out var parsedVersion) || parsedVersion == null)
+                return false;
+
+            version = parsedVersion;
+            return true;
+        }
+
+        private sealed class GitHubReleaseResponse
+        {
+            [JsonPropertyName("tag_name")]
+            public string? TagName { get; set; }
+
+            [JsonPropertyName("name")]
+            public string? Name { get; set; }
+
+            [JsonPropertyName("html_url")]
+            public string? HtmlUrl { get; set; }
+
+            [JsonPropertyName("body")]
+            public string? Body { get; set; }
+        }
+    }
+
+    internal sealed record ReleaseCheckResult(
+        bool IsUpdateAvailable,
+        Version CurrentVersion,
+        Version? LatestVersion,
+        string? LatestTag,
+        string? ReleaseName,
+        string? ReleaseUrl,
+        string? ReleaseNotes,
+        string? FailureReason)
+    {
+        public static ReleaseCheckResult NotAvailable(Version currentVersion, string reason) =>
+            new(false, currentVersion, null, null, null, null, null, reason);
+    }
+}


### PR DESCRIPTION
Adiciona suporte para verificação de atualizações no GitHub em `frmConfig.cs` com a implementação da classe `GitHubReleaseChecker`. Um novo item de menu foi adicionado para permitir que o usuário baixe a nova versão do aplicativo quando disponível. O método assíncrono `CheckForUpdatesAsync` foi implementado para realizar a verificação e notificar o usuário sobre novas versões. Além disso, o arquivo de projeto foi atualizado para a nova versão `1.0.2`.

Adiciona verificação de atualizações do GitHub

Implementa a classe GitHubReleaseChecker para verificar atualizações disponíveis. Adiciona item de menu para download de nova versão e métodos assíncronos para notificação de atualizações. Atualiza a versão do aplicativo para 1.0.2 e inclui novos namespaces necessários.